### PR TITLE
add logo as meta image for seo

### DIFF
--- a/templates/_layout.jinja2
+++ b/templates/_layout.jinja2
@@ -30,7 +30,8 @@
     {% block head %}
       <title>{{ title }} − PyConFR 2025</title>
       <meta charset="utf-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <meta property="og:image" content="{{ url_for('static', filename='images/logo-full.svg') }}"/>
 
       <link rel="shortcut icon" href="{{ url_for('static', filename='images/favicon.svg') }}" />
       <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') | version }}">


### PR DESCRIPTION
When I wanted to share the website, I noticed the following image was used by my previewer.
<img width="183" alt="Screenshot 2025-04-14 at 12 59 58" src="https://github.com/user-attachments/assets/2a4f1d80-ead9-44cb-8367-6f591e2b8298" />
So I added the PyConFR logo as opengraph image to have better sharing experience.