### PR TITLE
Revert "use absolute url for seo image instead of relative"

### DIFF
--- a/templates/_layout.jinja2
+++ b/templates/_layout.jinja2
@@ -31,7 +31,7 @@
       <title>{{ title }} − PyConFR 2025</title>
       <meta charset="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <meta property="og:image" content="{{ url_for('static', filename='images/logo-full.svg', _external=True) }}"/>
+      <meta property="og:image" content="{{ url_for('static', filename='images/logo-full.svg') }}"/>
 
       <link rel="shortcut icon" href="{{ url_for('static', filename='images/favicon.svg') }}" />
       <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') | version }}">


### PR DESCRIPTION
This reverts commit 2d5e59a2092ddb33d39769318f29f7c327677fa1.
After test, on production the image url is: "http://localhost/2025/static/images/logo-full.svg" instead of using the correct domain.
One way to fix the issue would have been to set `if not app.config["DEBUG"]:app.config["SERVER_NAME"] = "pycon.fr"` and to add `_scheme='https'` in `url_for` arguments. But this is kind of a bazooka technique since as per the [doc](https://flask.palletsprojects.com/en/stable/api/#flask.Flask.url_for) the domain name should be retrieved from current active request (locally we get correct url: "http://127.0.0.1:5000/2025/static/images/logo-full.svg").
A more correct solution might be to look into the reverse-proxy/wsgi server's configuration (see [similar issue](https://stackoverflow.com/questions/14810795/flask-url-for-generating-http-url-instead-of-https)).

In the meantime, simply revert to relative url event though it is less supported by seo crawler.